### PR TITLE
Work out a best practice about adding dependecy repository by virtue of ExternalProject_Add, without duplicated download.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 
 Textbook/
 build*/
-CMake_and_Makefile/cmake-*-tutorial-source/*
-CMake_and_Makefile/src/*
+CMake_and_Makefile/cmake-*-tutorial-source/
+CMake_and_Makefile/src/
 */.cache/
+
+CMake_and_Makefile/*/external/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,3 +8,5 @@ enable_testing()
 add_subdirectory(abstraction_mechanisms)
 add_subdirectory(Concurrency)
 add_subdirectory(UserTypes)
+
+add_subdirectory(UserSmartPointer)

--- a/CMake_and_Makefile/suppress_external_project_duplicated_download/CMakeLists.txt
+++ b/CMake_and_Makefile/suppress_external_project_duplicated_download/CMakeLists.txt
@@ -4,12 +4,35 @@ project(suppress_external_project_duplicated_download)
 
 
 include(googletest.cmake)
-# include(boost.cmake)
+include(boost.cmake)
+include(cpputest.cmake)
 
-file(GLOB_RECURSE sources "*.cpp")
-file(GLOB_RECURSE headers "*.hpp")
-list(FILTER sources EXCLUDE REGEX "build/*")
-list(FILTER headers EXCLUDE REGEX "build/*")
+
+file(GLOB_RECURSE sources 
+    LIST_DIRECTORIES false  # 此参数可避免将目录本身包含在结果中
+    CONFIGURE_DEPENDS       # 该选项会监控文件系统变化，当新增/删除文件时会自动触发CMake重新配置
+    "*.c*")
+file(GLOB_RECURSE headers 
+    LIST_DIRECTORIES false 
+    CONFIGURE_DEPENDS 
+    "*.h*")
+list(FILTER sources EXCLUDE REGEX "./external/*")
+list(FILTER headers EXCLUDE REGEX "./external/*")
+list(FILTER sources EXCLUDE REGEX "./build/*")
+list(FILTER headers EXCLUDE REGEX "./build/*")
+list(FILTER sources EXCLUDE REGEX ".*\\.cmake$")    # 使用正则表达式排除所有的.cmake文件
+
+message(STATUS "source files list: ")
+foreach(source ${sources})
+    message(STATUS "\t\t ${source}")
+endforeach()
+
+message(STATUS "header files list: ")
+foreach(header ${headers})
+    message(STATUS "\t\t ${header}")
+endforeach()
+
+
 
 
 message(STATUS "CMAKE_PROJECT_NAME = ${CMAKE_PROJECT_NAME}")
@@ -18,7 +41,7 @@ add_executable(${CMAKE_PROJECT_NAME}
     ${sources}
     ${headers})
 
-add_dependencies(${CMAKE_PROJECT_NAME} GTest)
+add_dependencies(${CMAKE_PROJECT_NAME} GTest cpputest Boost)
 
 set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
     CXX_STANDARD        17
@@ -32,8 +55,7 @@ target_link_directories(${CMAKE_PROJECT_NAME} PRIVATE
     ${GTEST_LIB_DIR})
 
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
-    gtest
-    gmock)
+    gtest)
 
 
 #===============================================================================

--- a/CMake_and_Makefile/suppress_external_project_duplicated_download/CMakeLists.txt
+++ b/CMake_and_Makefile/suppress_external_project_duplicated_download/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(suppress_external_project_duplicated_download)
+
+
+include(googletest.cmake)
+# include(boost.cmake)
+
+file(GLOB_RECURSE sources "*.cpp")
+file(GLOB_RECURSE headers "*.hpp")
+list(FILTER sources EXCLUDE REGEX "build/*")
+list(FILTER headers EXCLUDE REGEX "build/*")
+
+
+message(STATUS "CMAKE_PROJECT_NAME = ${CMAKE_PROJECT_NAME}")
+
+add_executable(${CMAKE_PROJECT_NAME}
+    ${sources}
+    ${headers})
+
+add_dependencies(${CMAKE_PROJECT_NAME} GTest)
+
+set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
+    CXX_STANDARD        17
+    CXX_EXTENSIONS      NO
+    CXX_STANDARD_REQUIRED   YES)
+
+target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
+    ${GTEST_INCLUDE_DIR})
+
+target_link_directories(${CMAKE_PROJECT_NAME} PRIVATE
+    ${GTEST_LIB_DIR})
+
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+    gtest
+    gmock)
+
+
+#===============================================================================
+
+enable_testing()
+
+add_test(NAME UTest_${CMAKE_PROJECT_NAME}
+    COMMAND $<TARGET_FILE:${CMAKE_PROJECT_NAME}>)
+
+include(GoogleTest)
+gtest_discover_tests(${CMAKE_PROJECT_NAME})

--- a/CMake_and_Makefile/suppress_external_project_duplicated_download/boost.cmake
+++ b/CMake_and_Makefile/suppress_external_project_duplicated_download/boost.cmake
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 3.20)
+
+
+set(BOOST_SRC_DIR           ${CMAKE_SOURCE_DIR}/external/boost-src)
+set(BOOST_STATE_DIR         ${CMAKE_BINARY_DIR}/boost-state)
+set(BOOST_INSTALL_DIR       ${CMAKE_BINARY_DIR}/boost-install)
+
+
+if (NOT EXISTS "${BOOST_SRC_DIR}/.git")
+    message(STATUS "Initialize the boost repository downloading...")
+
+    file(MAKE_DIRECTORY "${BOOST_SRC_DIR}")
+    find_program(GIT_EXECUTABLE git REQUIRED)
+    message(STATUS "GIT_EXECUTABLE = ${GIT_EXECUTABLE}")
+
+    set(GIT_TAG         boost-1.86.0)
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} clone --recurse-submodules --depth=10 --branch=${GIT_TAG} https://github.com/boostorg/boost.git ${BOOST_SRC_DIR}
+        WORKING_DIRECTORY       ${CMAKE_CURRENT_BINARY_DIR}
+        RESULT_VARIABLE         GIT_CLONE_RESULT
+    )
+
+    if (NOT GIT_CLONE_RESULT EQUAL 0)
+        message(FATAL_ERROR "Failed to git clone boost repository")
+    endif()
+endif()
+
+include(ExternalProject)
+
+ExternalProject_Add(Boost
+    PREFIX                  ${BOOST_STATE_DIR}
+    GIT_TAG                 boost-1.86.0
+    SOURCE_DIR              ${BOOST_SRC_DIR}
+    DOWNLOAD_COMMAND        ""
+    GIT_CONFIG              "core.worktree=${BOOST_SRC_DIR}"
+    CMAKE_ARGS
+        -DCMAKE_BUILD_TYPE=Release
+        -DBUILD_SHARED_LIBS=ON
+        -DCMAKE_INSTALL_PREFIX=${BOOST_INSTALL_DIR}
+    BUILD_ALWAYS            TRUE
+    STEP_TARGETS            install
+)
+
+set(BOOST_INCLUDE_DIR       ${BOOST_INSTALL_DIR}/include)
+set(BOOST_LIB_DIR           ${BOOST_INSTALL_DIR}/lib)

--- a/CMake_and_Makefile/suppress_external_project_duplicated_download/check_cpp_standard.cpp
+++ b/CMake_and_Makefile/suppress_external_project_duplicated_download/check_cpp_standard.cpp
@@ -1,0 +1,16 @@
+/*!
+ *  \file       check_cpp_standard.cpp
+ *  \brief      Make sure that current program is using the correct C++ standard no. you have specified.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+TEST(UTester4CppStandard, CheckCppStandardNo)
+{
+    std::cout << "Current C++ standard no. is " << __cplusplus << std::endl;
+    std::cout << "Current program is " << sizeof(void *) * 8 << "-bits.\n"
+              << std::endl;
+
+    EXPECT_TRUE(__cplusplus == 201703L);
+}

--- a/CMake_and_Makefile/suppress_external_project_duplicated_download/cpputest.cmake
+++ b/CMake_and_Makefile/suppress_external_project_duplicated_download/cpputest.cmake
@@ -1,0 +1,65 @@
+cmake_minimum_required(VERSION 3.20)
+
+
+set(CppUTest_SRC_DIR            ${CMAKE_SOURCE_DIR}/external/cpputest-src)
+set(CppUTest_STATE_DIR          ${CMAKE_BINARY_DIR}/cpputest-state)
+set(CppUTest_INSTALL_DIR        ${CMAKE_BINARY_DIR}/cpputest-install)
+
+set(GIT_TAG_NAME        master)
+set(GIT_CLONE_DEPTH     10)
+
+find_program(GIT_EXECUTABLE git REQUIRED)
+
+# 首次克隆或检查版本变更处理
+if (NOT EXISTS "${CppUTest_SRC_DIR}/.git")
+    message(STATUS "git cloning (shallow) cpputest repository...")
+
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} clone --depth=${GIT_CLONE_DEPTH} --branch=${GIT_TAG_NAME} https://github.com/cpputest/cpputest.git ${CppUTest_SRC_DIR}
+        WORKING_DIRECTORY       ${CMAKE_CURRENT_BINARY_DIR}
+        RESULT_VARIABLE         GIT_CLONE_RESULT
+    )
+
+    if (NOT GIT_CLONE_RESULT EQUAL 0)
+        message(FATAL_ERROR "Failed to git clone the cpputest repository!")
+    endif()
+else()
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} -C ${CppUTest_SRC_DIR} describe --tags --exact-match HEAD
+        OUTPUT_VARIABLE current_version_tag
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if (NOT "${current_version_tag}" STREQUAL "${GIT_TAG_NAME}")
+        message(STATUS "Switching cpputest to ${GIT_TAG_NAME}...")
+
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} -C ${CppUTest_SRC_DIR} fetch --depth=${GIT_CLONE_DEPTH} origin ${GIT_TAG_NAME}:${GIT_TAG_NAME}
+            COMMAND ${GIT_EXECUTABLE} -C ${CppUTest_SRC_DIR} checkout ${GIT_TAG_NAME}
+            RESULT_VARIABLE result
+        )
+        if (NOT result EQUAL 0)
+            message(STATUS "Failed to switch to your expected ${GIT_TAG_NAME}")
+        endif()
+    endif()
+endif()
+
+
+include(ExternalProject)
+ExternalProject_Add(cpputest
+    PREFIX                  ${CppUTest_STATE_DIR}
+    SOURCE_DIR              ${CppUTest_SRC_DIR}
+    DOWNLOAD_COMMAND        ""
+    GIT_CONFIG              "core.worktree=${CppUTest_SRC_DIR}"
+    UPDATE_DISCONNECTED     TRUE
+    CMAKE_ARGS
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        -DBUILD_SHARED_LIBS=ON
+        -DCMAKE_INSTALL_PREFIX=${CppUTest_INSTALL_DIR}
+    BUILD_ALWAYS            TRUE
+    LOG_BUILD               ON
+    STEP_TARGETS            install
+)
+
+
+set(CppUTest_INCLUDE_DIR        ${CppUTest_INSTALL_DIR}/include)
+set(CppUTest_LIB_DIR            ${CppUTest_INSTALL_DIR}/lib)

--- a/CMake_and_Makefile/suppress_external_project_duplicated_download/googletest.cmake
+++ b/CMake_and_Makefile/suppress_external_project_duplicated_download/googletest.cmake
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.20)
+
+# 定义永久存储目录
+set(GTEST_SRC_DIR       ${CMAKE_SOURCE_DIR}/external/gtest-src)
+set(GTEST_STATE_DIR     ${CMAKE_BINARY_DIR}/gtest-state)
+set(GTEST_INSTALL_DIR   ${CMAKE_BINARY_DIR}/gtest-install)
+
+
+# 首次下载检查
+if (NOT EXISTS "${GTEST_SRC_DIR}/.git")
+    message(STATUS "Initial GTest downloading...")
+
+    file(MAKE_DIRECTORY "${GTEST_SRC_DIR}")
+    find_program(GIT_EXECUTABLE git REQUIRED)
+
+    message(STATUS "GIT_EXECUTABLE = ${GIT_EXECUTABLE}")
+
+    set(GIT_BRANCH_NAME     main)
+    set(GIT_TAG_NAME        v1.17.0)
+
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} clone --depth 10 --branch "${GIT_TAG_NAME}" https://github.com/google/googletest.git "${GTEST_SRC_DIR}"
+        WORKING_DIRECTORY   "${CMAKE_CURRENT_BINARY_DIR}"
+        RESULT_VARIABLE     GIT_CLONE_RESULT
+    )
+
+    if (NOT GIT_CLONE_RESULT EQUAL 0)
+        message(FATAL_ERROR "Failed to git clone googletest repo.")
+    endif()
+endif()
+
+include(ExternalProject)
+
+ExternalProject_Add(GTest
+    PREFIX              ${GTEST_STATE_DIR}      # 构建状态隔离存储
+    SOURCE_DIR          ${GTEST_SRC_DIR}        # 绑定永久源码目录
+    DOWNLOAD_COMMAND    ""                      # 禁用默认下载
+    GIT_CONFIG          "core.worktree=${GTEST_SRC_DIR}"    # 强制绑定本地仓库
+    UPDATE_DISCONNECTED     ON          # 绝对禁用远程更新
+    CMAKE_ARGS
+        # -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        -DBUILD_SHARED_LIBS=ON
+        -DCMAKE_INSTALL_PREFIX=${GTEST_INSTALL_DIR}
+    BUILD_ALWAYS            TRUE
+    LOG_BUILD               ON
+    STEP_TARGETS            install
+)
+
+set(GTEST_INCLUDE_DIR       ${GTEST_INSTALL_DIR}/include)
+set(GTEST_LIB_DIR           ${GTEST_INSTALL_DIR}/lib)

--- a/CMake_and_Makefile/suppress_external_project_duplicated_download/main.cpp
+++ b/CMake_and_Makefile/suppress_external_project_duplicated_download/main.cpp
@@ -1,0 +1,19 @@
+/*!
+ *  \file       main.cpp
+ *  \brief
+ *
+ */
+
+#include <iostream>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+int main(int argc, char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
- I have worked out a best practice about adding dependency repository

> 1. by using ExternalProject_Add(), add the dependency library for your main project, 
> 2. clone library repository into your main project as external libraries
> 3. have the source directory, e.g. external/cpputest-src/, and build state directory, e.g. build/cpputest-state/ stored separately, bond GIT_CONFIG's <code>core.worktree=cpputest-src</code>.  With these settings, it can avoid the duplicated repo. downloading, even though the entire build/ directory were removed.
> 4. utilize <code>execute_process</code> to manage the repo git-clone, allow user to specify tag or branch, and clone-depth.
> 